### PR TITLE
set default writer earlier

### DIFF
--- a/cmds/root.go
+++ b/cmds/root.go
@@ -24,8 +24,6 @@ var (
 )
 
 func setOutputWriter() {
-	outputwriter.SetWriter(outputwriter.CreateDefaultWriter())
-
 	if jsonOutput && yamlOutput {
 		outputwriter.GetWriter().WriteError(fmt.Errorf("only one of json or yaml output can be selected"))
 		os.Exit(1)
@@ -53,6 +51,7 @@ var rootCmd = &cobra.Command{
 }
 
 func Execute() {
+	outputwriter.SetWriter(outputwriter.CreateDefaultWriter())
 	if err := rootCmd.Execute(); err != nil {
 		outputwriter.GetWriter().WriteError(fmt.Errorf("error while executing root command %s", err))
 		os.Exit(1)


### PR DESCRIPTION
closes dfds/cloudplatform/issues/2772

# Changes Introduced
* Setup default outputwriter earlier in the process

# Notes
When passing illegal arguments, the rootCmd fails with an error.
If so, we never set up our output writer, and thus panic on a null pointer exception when trying to write the problem to the user.