### PR TITLE
Print command for authentication details

### DIFF
--- a/cmds/authentication/authentication.go
+++ b/cmds/authentication/authentication.go
@@ -21,6 +21,7 @@ var AuthenticationCmd = &cobra.Command{
 
 func InitializeAuthentication() {
 	AuthenticationCmd.AddCommand(clearInformationCmd)
+	AuthenticationCmd.AddCommand(printTokenCmd)
 }
 
 func authenticateCmdFunction(cmd *cobra.Command, args []string) {
@@ -50,5 +51,13 @@ var clearInformationCmd = &cobra.Command{
 	Short: "removes all stored authentication data",
 	Run: func(cmd *cobra.Command, args []string) {
 		configuration.ClearAccessToken()
+	},
+}
+
+var printTokenCmd = &cobra.Command{
+	Use:   "print",
+	Short: "print the stored access token",
+	Run: func(cmd *cobra.Command, args []string) {
+		configuration.PrintAccessToken()
 	},
 }

--- a/cmds/configuration/configuration.go
+++ b/cmds/configuration/configuration.go
@@ -94,6 +94,10 @@ func ClearAccessToken() {
 	os.Remove(fmt.Sprintf("%s/%s", configPath, accessTokenFile))
 }
 
+func PrintAccessToken() {
+	outputwriter.GetWriter().WriteData(viper.GetString("access-token"))
+}
+
 func BindFlag(key string, flag *pflag.Flag) {
 	viper.BindPFlag(key, flag)
 }


### PR DESCRIPTION
closes dfds/cloudplatform/issues/2805

# Changes Introduced
* New `authenticate print` command for printing current token

# Notes
Useful when wanting the token for other tools, e.g. Postman.
