### PR TITLE
cleanup and aws-azure resources

### DIFF
--- a/api.json
+++ b/api.json
@@ -53,8 +53,8 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "Success",
+          "201": {
+            "description": "Created",
             "content": {
               "application/json": {
                 "schema": {
@@ -209,6 +209,139 @@
           },
           "409": {
             "description": "Conflict"
+          }
+        }
+      }
+    },
+    "/capabilities/{id}/azureresources": {
+      "get": {
+        "tags": [
+          "Capability"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AwsAccountApiResource"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Capability"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewAzureResourceRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewAzureResourceRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewAzureResourceRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AwsAccountApiResource"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "409": {
+            "description": "Conflict"
+          }
+        }
+      }
+    },
+    "/capabilities/{id}/azureresources/{rid}": {
+      "get": {
+        "tags": [
+          "Capability"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "rid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AwsAccountApiResource"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -816,7 +949,17 @@
         ],
         "responses": {
           "200": {
-            "description": "Success"
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ECRRepository"
+                  }
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized"
@@ -854,7 +997,14 @@
         },
         "responses": {
           "200": {
-            "description": "Success"
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ECRRepository"
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized"
@@ -2365,6 +2515,9 @@
           "awsAccount": {
             "$ref": "#/components/schemas/ResourceLink"
           },
+          "azureResources": {
+            "$ref": "#/components/schemas/ResourceLink"
+          },
           "requestCapabilityDeletion": {
             "$ref": "#/components/schemas/ResourceLink"
           },
@@ -2500,6 +2653,36 @@
             "nullable": true
           }
         },
+        "additionalProperties": false
+      },
+      "ECRRepository": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ECRRepositoryId"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "requestedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ECRRepositoryId": {
+        "type": "object",
         "additionalProperties": false
       },
       "InvitationsRequest": {
@@ -2811,6 +2994,19 @@
         "properties": {
           "self": {
             "$ref": "#/components/schemas/ResourceLink"
+          }
+        },
+        "additionalProperties": false
+      },
+      "NewAzureResourceRequest": {
+        "required": [
+          "environment"
+        ],
+        "type": "object",
+        "properties": {
+          "environment": {
+            "minLength": 1,
+            "type": "string"
           }
         },
         "additionalProperties": false

--- a/cmds/capability/awsAccounts.go
+++ b/cmds/capability/awsAccounts.go
@@ -1,0 +1,50 @@
+package capability
+
+import (
+	"context"
+
+	"go.dfds.cloud/ticli/cmds/outputwriter"
+
+	"github.com/spf13/cobra"
+)
+
+var AWSCmd = &cobra.Command{
+	Use:   "aws",
+	Short: "query topics",
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Help()
+	},
+}
+
+func InitAWS(accessToken string) {
+	AWSCmd.AddCommand(getAccountCmd)
+	getAccountCmd.AddCommand(createAccountCmd)
+}
+
+var getAccountCmd = &cobra.Command{
+	Use:   "account",
+	Short: "get connected aws account",
+	Run: func(cmd *cobra.Command, args []string) {
+		if cmd.Flags().Changed("id") {
+			topics, err := selfserviceClient.GetCapabilitiesIdAwsaccountWithResponse(context.Background(), CapabilityId)
+			if err != nil {
+				outputwriter.GetWriter().WriteError(err)
+			}
+			outputwriter.GetWriter().WriteData(topics.JSON200)
+		} else {
+			outputwriter.GetWriter().WriteError(NoIdError)
+		}
+	},
+}
+
+var createAccountCmd = &cobra.Command{
+	Use:   "create",
+	Short: "create an aws account for this capability",
+	Run: func(cmd *cobra.Command, args []string) {
+		account, err := selfserviceClient.PostCapabilitiesIdAwsaccountWithResponse(context.Background(), CapabilityId)
+		if err != nil {
+			outputwriter.GetWriter().WriteError(err)
+		}
+		outputwriter.GetWriter().WriteData(account.JSON200)
+	},
+}

--- a/cmds/capability/azureResourceGroups.go
+++ b/cmds/capability/azureResourceGroups.go
@@ -1,0 +1,62 @@
+package capability
+
+import (
+	"context"
+	"errors"
+
+	"github.com/spf13/cobra"
+	"go.dfds.cloud/ticli/cmds/outputwriter"
+	"go.dfds.cloud/ticli/openapiclient"
+)
+
+var AzureCmd = &cobra.Command{
+	Use:   "azure",
+	Short: "query azure",
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Help()
+	},
+}
+
+func InitAzure(accessToken string) {
+	AzureCmd.AddCommand(azureResourceGroupsCmd)
+	azureResourceGroupsCmd.AddCommand(createResourceGroupCmd)
+}
+
+var azureResourceGroupsCmd = &cobra.Command{
+	Use:   "resource-groups",
+	Short: "get connected azure resource groups",
+	Run: func(cmd *cobra.Command, args []string) {
+		if cmd.Flags().Changed("id") {
+			resourceGroups, err := selfserviceClient.GetCapabilitiesIdAzureresourcesWithResponse(context.Background(), CapabilityId)
+
+			if err != nil {
+				outputwriter.GetWriter().WriteError(err)
+			}
+			outputwriter.GetWriter().WriteData(resourceGroups.JSON200)
+		} else {
+			outputwriter.GetWriter().WriteError(NoIdError)
+		}
+
+	},
+}
+
+var createResourceGroupCmd = &cobra.Command{
+	Use:   "create [ENVIRONMENT]",
+	Short: "create a new azure resource group in the designated environment",
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) == 1 {
+			environment := args[0]
+			var resourceGroupRequest = openapiclient.NewAzureResourceRequest{
+				Environment: environment,
+			}
+
+			resourceGroup, err := selfserviceClient.PostCapabilitiesIdAzureresourcesWithResponse(context.Background(), CapabilityId, resourceGroupRequest)
+			if err != nil {
+				outputwriter.GetWriter().WriteError(err)
+			}
+			outputwriter.GetWriter().WriteData(resourceGroup.JSON200)
+		} else {
+			outputwriter.GetWriter().WriteError(errors.New("No environment specified"))
+		}
+	},
+}

--- a/cmds/ecr-repositories/ecr-repositories.go
+++ b/cmds/ecr-repositories/ecr-repositories.go
@@ -3,9 +3,9 @@ package ecr_repositories
 import (
 	"context"
 	"fmt"
-	"go.dfds.cloud/ticli/openapiclient"
-	"log"
 	"os"
+
+	"go.dfds.cloud/ticli/openapiclient"
 
 	"go.dfds.cloud/ticli/cmds/configuration"
 
@@ -47,7 +47,7 @@ var queryCmd = &cobra.Command{
 		repositories, err := selfserviceClient.GetEcrRepositoriesWithResponse(context.Background())
 
 		if err != nil {
-			log.Fatal(err)
+			outputwriter.GetWriter().WriteError(err)
 		}
 
 		outputwriter.GetWriter().WriteData(repositories.JSON200)
@@ -70,7 +70,7 @@ var createECRCmd = &cobra.Command{
 		ecr, err := selfserviceClient.PostEcrRepositoriesWithResponse(context.Background(), ecrStruct)
 
 		if err != nil {
-			log.Fatal(err)
+			outputwriter.GetWriter().WriteError(err)
 		}
 
 		outputwriter.GetWriter().WriteData(ecr.JSON200)

--- a/cmds/kafka-topics/topics.go
+++ b/cmds/kafka-topics/topics.go
@@ -2,11 +2,10 @@ package kafka_topics
 
 import (
 	"context"
-	"fmt"
+
 	"go.dfds.cloud/ticli/cmds/outputwriter"
 	"go.dfds.cloud/ticli/openapiclient"
 	"go.dfds.cloud/ticli/selfservice"
-	"log"
 
 	"github.com/spf13/cobra"
 )
@@ -38,10 +37,9 @@ var queryCmd = &cobra.Command{
 		topics, err := selfserviceClient.GetKafkatopicsWithResponse(context.Background(), nil)
 
 		if err != nil {
-			log.Fatal(err)
+			outputwriter.GetWriter().WriteError(err)
 		}
 
-		fmt.Println(topics.StatusCode())
 		outputwriter.GetWriter().WriteData(topics.JSON200)
 	},
 }

--- a/openapiclient/openapiclient.gen.go
+++ b/openapiclient/openapiclient.gen.go
@@ -60,6 +60,7 @@ type CapabilityDetailsApiResource struct {
 // CapabilityDetailsLinks defines model for CapabilityDetailsLinks.
 type CapabilityDetailsLinks struct {
 	AwsAccount                      *ResourceLink `json:"awsAccount,omitempty"`
+	AzureResources                  *ResourceLink `json:"azureResources,omitempty"`
 	CancelCapabilityDeletionRequest *ResourceLink `json:"cancelCapabilityDeletionRequest,omitempty"`
 	Clusters                        *ResourceLink `json:"clusters,omitempty"`
 	ConfigurationLevel              *ResourceLink `json:"configurationLevel,omitempty"`
@@ -262,6 +263,11 @@ type MembershipApprovalListLinks struct {
 	Self *ResourceLink `json:"self,omitempty"`
 }
 
+// NewAzureResourceRequest defines model for NewAzureResourceRequest.
+type NewAzureResourceRequest struct {
+	Environment string `json:"environment"`
+}
+
 // NewCapabilityRequest defines model for NewCapabilityRequest.
 type NewCapabilityRequest struct {
 	Description  *string   `json:"description"`
@@ -373,6 +379,12 @@ type PostCapabilitiesApplicationWildcardPlusJSONRequestBody = NewCapabilityReque
 
 // PostCapabilitiesJSONRequestBody defines body for PostCapabilities for application/json ContentType.
 type PostCapabilitiesJSONRequestBody = NewCapabilityRequest
+
+// PostCapabilitiesIdAzureresourcesApplicationWildcardPlusJSONRequestBody defines body for PostCapabilitiesIdAzureresources for application/*+json ContentType.
+type PostCapabilitiesIdAzureresourcesApplicationWildcardPlusJSONRequestBody = NewAzureResourceRequest
+
+// PostCapabilitiesIdAzureresourcesJSONRequestBody defines body for PostCapabilitiesIdAzureresources for application/json ContentType.
+type PostCapabilitiesIdAzureresourcesJSONRequestBody = NewAzureResourceRequest
 
 // PostCapabilitiesIdInvitationsApplicationWildcardPlusJSONRequestBody defines body for PostCapabilitiesIdInvitations for application/*+json ContentType.
 type PostCapabilitiesIdInvitationsApplicationWildcardPlusJSONRequestBody = InvitationsRequest
@@ -671,6 +683,19 @@ type ClientInterface interface {
 
 	// PostCapabilitiesIdAwsaccount request
 	PostCapabilitiesIdAwsaccount(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetCapabilitiesIdAzureresources request
+	GetCapabilitiesIdAzureresources(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PostCapabilitiesIdAzureresourcesWithBody request with any body
+	PostCapabilitiesIdAzureresourcesWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	PostCapabilitiesIdAzureresourcesWithApplicationWildcardPlusJSONBody(ctx context.Context, id string, body PostCapabilitiesIdAzureresourcesApplicationWildcardPlusJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	PostCapabilitiesIdAzureresources(ctx context.Context, id string, body PostCapabilitiesIdAzureresourcesJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetCapabilitiesIdAzureresourcesRid request
+	GetCapabilitiesIdAzureresourcesRid(ctx context.Context, id string, rid string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// PostCapabilitiesIdCanceldeletionrequest request
 	PostCapabilitiesIdCanceldeletionrequest(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -996,6 +1021,66 @@ func (c *Client) GetCapabilitiesIdAwsaccount(ctx context.Context, id string, req
 
 func (c *Client) PostCapabilitiesIdAwsaccount(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewPostCapabilitiesIdAwsaccountRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetCapabilitiesIdAzureresources(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetCapabilitiesIdAzureresourcesRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostCapabilitiesIdAzureresourcesWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostCapabilitiesIdAzureresourcesRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostCapabilitiesIdAzureresourcesWithApplicationWildcardPlusJSONBody(ctx context.Context, id string, body PostCapabilitiesIdAzureresourcesApplicationWildcardPlusJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostCapabilitiesIdAzureresourcesRequestWithApplicationWildcardPlusJSONBody(c.Server, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostCapabilitiesIdAzureresources(ctx context.Context, id string, body PostCapabilitiesIdAzureresourcesJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostCapabilitiesIdAzureresourcesRequest(c.Server, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetCapabilitiesIdAzureresourcesRid(ctx context.Context, id string, rid string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetCapabilitiesIdAzureresourcesRidRequest(c.Server, id, rid)
 	if err != nil {
 		return nil, err
 	}
@@ -2236,6 +2321,139 @@ func NewPostCapabilitiesIdAwsaccountRequest(server string, id string) (*http.Req
 	}
 
 	req, err := http.NewRequest("POST", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetCapabilitiesIdAzureresourcesRequest generates requests for GetCapabilitiesIdAzureresources
+func NewGetCapabilitiesIdAzureresourcesRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/capabilities/%s/azureresources", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewPostCapabilitiesIdAzureresourcesRequestWithApplicationWildcardPlusJSONBody calls the generic PostCapabilitiesIdAzureresources builder with application/*+json body
+func NewPostCapabilitiesIdAzureresourcesRequestWithApplicationWildcardPlusJSONBody(server string, id string, body PostCapabilitiesIdAzureresourcesApplicationWildcardPlusJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewPostCapabilitiesIdAzureresourcesRequestWithBody(server, id, "application/*+json", bodyReader)
+}
+
+// NewPostCapabilitiesIdAzureresourcesRequest calls the generic PostCapabilitiesIdAzureresources builder with application/json body
+func NewPostCapabilitiesIdAzureresourcesRequest(server string, id string, body PostCapabilitiesIdAzureresourcesJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewPostCapabilitiesIdAzureresourcesRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewPostCapabilitiesIdAzureresourcesRequestWithBody generates requests for PostCapabilitiesIdAzureresources with any type of body
+func NewPostCapabilitiesIdAzureresourcesRequestWithBody(server string, id string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/capabilities/%s/azureresources", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewGetCapabilitiesIdAzureresourcesRidRequest generates requests for GetCapabilitiesIdAzureresourcesRid
+func NewGetCapabilitiesIdAzureresourcesRidRequest(server string, id string, rid string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "rid", runtime.ParamLocationPath, rid)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/capabilities/%s/azureresources/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -4663,6 +4881,19 @@ type ClientWithResponsesInterface interface {
 	// PostCapabilitiesIdAwsaccountWithResponse request
 	PostCapabilitiesIdAwsaccountWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*PostCapabilitiesIdAwsaccountResponse, error)
 
+	// GetCapabilitiesIdAzureresourcesWithResponse request
+	GetCapabilitiesIdAzureresourcesWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*GetCapabilitiesIdAzureresourcesResponse, error)
+
+	// PostCapabilitiesIdAzureresourcesWithBodyWithResponse request with any body
+	PostCapabilitiesIdAzureresourcesWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostCapabilitiesIdAzureresourcesResponse, error)
+
+	PostCapabilitiesIdAzureresourcesWithApplicationWildcardPlusJSONBodyWithResponse(ctx context.Context, id string, body PostCapabilitiesIdAzureresourcesApplicationWildcardPlusJSONRequestBody, reqEditors ...RequestEditorFn) (*PostCapabilitiesIdAzureresourcesResponse, error)
+
+	PostCapabilitiesIdAzureresourcesWithResponse(ctx context.Context, id string, body PostCapabilitiesIdAzureresourcesJSONRequestBody, reqEditors ...RequestEditorFn) (*PostCapabilitiesIdAzureresourcesResponse, error)
+
+	// GetCapabilitiesIdAzureresourcesRidWithResponse request
+	GetCapabilitiesIdAzureresourcesRidWithResponse(ctx context.Context, id string, rid string, reqEditors ...RequestEditorFn) (*GetCapabilitiesIdAzureresourcesRidResponse, error)
+
 	// PostCapabilitiesIdCanceldeletionrequestWithResponse request
 	PostCapabilitiesIdCanceldeletionrequestWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*PostCapabilitiesIdCanceldeletionrequestResponse, error)
 
@@ -5035,6 +5266,72 @@ func (r PostCapabilitiesIdAwsaccountResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r PostCapabilitiesIdAwsaccountResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetCapabilitiesIdAzureresourcesResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *AwsAccountApiResource
+}
+
+// Status returns HTTPResponse.Status
+func (r GetCapabilitiesIdAzureresourcesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetCapabilitiesIdAzureresourcesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type PostCapabilitiesIdAzureresourcesResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *AwsAccountApiResource
+}
+
+// Status returns HTTPResponse.Status
+func (r PostCapabilitiesIdAzureresourcesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PostCapabilitiesIdAzureresourcesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetCapabilitiesIdAzureresourcesRidResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *AwsAccountApiResource
+}
+
+// Status returns HTTPResponse.Status
+func (r GetCapabilitiesIdAzureresourcesRidResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetCapabilitiesIdAzureresourcesRidResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -6380,6 +6677,49 @@ func (c *ClientWithResponses) PostCapabilitiesIdAwsaccountWithResponse(ctx conte
 	return ParsePostCapabilitiesIdAwsaccountResponse(rsp)
 }
 
+// GetCapabilitiesIdAzureresourcesWithResponse request returning *GetCapabilitiesIdAzureresourcesResponse
+func (c *ClientWithResponses) GetCapabilitiesIdAzureresourcesWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*GetCapabilitiesIdAzureresourcesResponse, error) {
+	rsp, err := c.GetCapabilitiesIdAzureresources(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetCapabilitiesIdAzureresourcesResponse(rsp)
+}
+
+// PostCapabilitiesIdAzureresourcesWithBodyWithResponse request with arbitrary body returning *PostCapabilitiesIdAzureresourcesResponse
+func (c *ClientWithResponses) PostCapabilitiesIdAzureresourcesWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostCapabilitiesIdAzureresourcesResponse, error) {
+	rsp, err := c.PostCapabilitiesIdAzureresourcesWithBody(ctx, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostCapabilitiesIdAzureresourcesResponse(rsp)
+}
+
+func (c *ClientWithResponses) PostCapabilitiesIdAzureresourcesWithApplicationWildcardPlusJSONBodyWithResponse(ctx context.Context, id string, body PostCapabilitiesIdAzureresourcesApplicationWildcardPlusJSONRequestBody, reqEditors ...RequestEditorFn) (*PostCapabilitiesIdAzureresourcesResponse, error) {
+	rsp, err := c.PostCapabilitiesIdAzureresourcesWithApplicationWildcardPlusJSONBody(ctx, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostCapabilitiesIdAzureresourcesResponse(rsp)
+}
+
+func (c *ClientWithResponses) PostCapabilitiesIdAzureresourcesWithResponse(ctx context.Context, id string, body PostCapabilitiesIdAzureresourcesJSONRequestBody, reqEditors ...RequestEditorFn) (*PostCapabilitiesIdAzureresourcesResponse, error) {
+	rsp, err := c.PostCapabilitiesIdAzureresources(ctx, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostCapabilitiesIdAzureresourcesResponse(rsp)
+}
+
+// GetCapabilitiesIdAzureresourcesRidWithResponse request returning *GetCapabilitiesIdAzureresourcesRidResponse
+func (c *ClientWithResponses) GetCapabilitiesIdAzureresourcesRidWithResponse(ctx context.Context, id string, rid string, reqEditors ...RequestEditorFn) (*GetCapabilitiesIdAzureresourcesRidResponse, error) {
+	rsp, err := c.GetCapabilitiesIdAzureresourcesRid(ctx, id, rid, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetCapabilitiesIdAzureresourcesRidResponse(rsp)
+}
+
 // PostCapabilitiesIdCanceldeletionrequestWithResponse request returning *PostCapabilitiesIdCanceldeletionrequestResponse
 func (c *ClientWithResponses) PostCapabilitiesIdCanceldeletionrequestWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*PostCapabilitiesIdCanceldeletionrequestResponse, error) {
 	rsp, err := c.PostCapabilitiesIdCanceldeletionrequest(ctx, id, reqEditors...)
@@ -7248,6 +7588,84 @@ func ParsePostCapabilitiesIdAwsaccountResponse(rsp *http.Response) (*PostCapabil
 	}
 
 	response := &PostCapabilitiesIdAwsaccountResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest AwsAccountApiResource
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetCapabilitiesIdAzureresourcesResponse parses an HTTP response from a GetCapabilitiesIdAzureresourcesWithResponse call
+func ParseGetCapabilitiesIdAzureresourcesResponse(rsp *http.Response) (*GetCapabilitiesIdAzureresourcesResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetCapabilitiesIdAzureresourcesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest AwsAccountApiResource
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePostCapabilitiesIdAzureresourcesResponse parses an HTTP response from a PostCapabilitiesIdAzureresourcesWithResponse call
+func ParsePostCapabilitiesIdAzureresourcesResponse(rsp *http.Response) (*PostCapabilitiesIdAzureresourcesResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PostCapabilitiesIdAzureresourcesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest AwsAccountApiResource
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetCapabilitiesIdAzureresourcesRidResponse parses an HTTP response from a GetCapabilitiesIdAzureresourcesRidWithResponse call
+func ParseGetCapabilitiesIdAzureresourcesRidResponse(rsp *http.Response) (*GetCapabilitiesIdAzureresourcesRidResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetCapabilitiesIdAzureresourcesRidResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}

--- a/selfservice/selfserviceClient.go
+++ b/selfservice/selfserviceClient.go
@@ -5,12 +5,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"go.dfds.cloud/ticli/openapiclient"
 	"io"
-	"log"
 	"net/http"
 	"os"
 	"time"
+
+	"go.dfds.cloud/ticli/openapiclient"
 
 	"go.dfds.cloud/ticli/cmds/outputwriter"
 )
@@ -33,7 +33,7 @@ func NewGeneratedClient(accessToken string) *openapiclient.ClientWithResponses {
 	}))
 
 	if err != nil {
-		log.Fatal(err)
+		outputwriter.GetWriter().WriteError(err)
 	}
 
 	return apiClient


### PR DESCRIPTION
closes dfds/cloudplatform/issues/2796

# Changes Introduced
* Removed `log.Fatal(err)` and use `outputwriter.GetWriter().WriteError(err)`
* Add commands for 'aws account' to both view and create
* Add commands for 'azure resource-groups' to both view and create
* Remove separate command for querying specific capability, instead relying on the presence of an id-flag to determine this

# Notes
 I suggest renaming `capability` command to `capabilities` and similarly for all other commands currently focussing on singular items, when the default should be a list of items.
 Similarly I suggest renaming `query` to `list` or something similar. Query is a strange rune for fetching things in a CLI I believe.
 
 Both of these suggestions are breaking changes, and thus not introduced before we have some discussion around this